### PR TITLE
Change accountId to apiKey because we are adding a direct integration…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,8 +16,8 @@ var Chameleon = module.exports = integration('Chameleon')
   .readyOnInitialize()
   .readyOnLoad()
   .global('chmln')
-  .option('accountId', null)
-  .tag('<script src="https://fast.trychameleon.com/messo/{{accountId}}/messo.min.js"></script>');
+  .option('apiKey', null)
+  .tag('<script src="https://fast.trychameleon.com/messo/{{apiKey}}/messo.min.js"></script>');
 
 /**
  * Initialize Chameleon.
@@ -27,7 +27,7 @@ var Chameleon = module.exports = integration('Chameleon')
 
 Chameleon.prototype.initialize = function() {
   /* eslint-disable */
-  var c=(window.chmln||(window.chmln={}));c.location=window.location.href.toString();c.accountToken=this.options.accountId;var names='setup identify alias track set show on off custom help _data'.split(' ');for (var i=0;i<names.length;i++){(function(){var t=c[names[i]+'_a']=[];c[names[i]]=function(){t.push(arguments);};})()};
+  var c=(window.chmln||(window.chmln={}));c.location=window.location.href.toString();c.accountToken=this.options.apiKey;var names='setup identify alias track set show on off custom help _data'.split(' ');for (var i=0;i<names.length;i++){(function(){var t=c[names[i]+'_a']=[];c[names[i]]=function(){t.push(arguments);};})()};
   /* eslint-enable */
 
   this.ready();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,7 +12,7 @@ describe('Chameleon', function() {
   var analytics;
   var chameleon;
   var options = {
-    accountId: 'AvyQ4N2p-FOb5ceEb3w0RT-segment-integration'
+    apiKey: 'AvyQ4N2p-FOb5ceEb3w0RT-segment-integration'
   };
 
   beforeEach(function() {
@@ -39,7 +39,7 @@ describe('Chameleon', function() {
       .readyOnInitialize()
       .readyOnLoad()
       .global('chmln')
-      .option('accountId', null));
+      .option('apiKey', null));
   });
 
   describe('before loading', function() {
@@ -59,7 +59,7 @@ describe('Chameleon', function() {
       });
 
       it('should add the account token', function() {
-        analytics.assert.equal(window.chmln.accountToken, options.accountId);
+        analytics.assert.equal(window.chmln.accountToken, options.apiKey);
       });
 
       it('should load', function() {


### PR DESCRIPTION
… component so Chameleon can receive data from mobile and servers, and direct integrations must have the credential be named apiKey. I have also created a mongo script to change this in mongo.
